### PR TITLE
fix: never block OBS shutdown in HTTP worker teardown

### DIFF
--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -58,8 +58,14 @@ static void workerLoop()
 	while (true) {
 		std::unique_lock<std::mutex> lock(queue_mutex);
 		queue_cv.wait(lock, [] { return !async_queue.empty() || stop_worker; });
-		if (stop_worker && async_queue.empty())
+		if (stop_worker) {
+			// Shutting down: drop queued requests and exit. Draining them
+			// here could block module unload for the full timeout of every
+			// pending request.
+			while (!async_queue.empty())
+				async_queue.pop();
 			break;
+		}
 		AsyncRequest req = async_queue.front();
 		async_queue.pop();
 		lock.unlock();
@@ -70,12 +76,19 @@ static void workerLoop()
 		} else {
 			response = HttpClient::get(req.url, req.headers, req.timeout_ms);
 		}
+		lock.lock();
+		bool stale = stop_worker;
+		lock.unlock();
+		if (stale)
+			break; // unload in progress: skip callbacks that may touch destroyed state
 		req.callback(response);
 	}
 }
 
 void HttpClient::init()
 {
+	if (worker_thread.joinable())
+		return;
 	curl_global_init(CURL_GLOBAL_ALL);
 	stop_worker = false;
 	worker_thread = std::thread(workerLoop);
@@ -88,9 +101,11 @@ void HttpClient::cleanup()
 		stop_worker = true;
 	}
 	queue_cv.notify_all();
+	// Never block OBS shutdown: the worker exits by itself once the request
+	// in flight (if any) returns. curl_global_cleanup() is skipped for the
+	// same reason; it is optional at process exit.
 	if (worker_thread.joinable())
-		worker_thread.join();
-	curl_global_cleanup();
+		worker_thread.detach();
 }
 
 HttpResponse HttpClient::get(const std::string &url, const std::vector<std::string> &headers, long timeout_ms)

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -152,8 +152,8 @@ HttpResponse HttpClient::get(const std::string &url, const std::vector<std::stri
 	return response;
 }
 
-HttpResponse HttpClient::post(const std::string &url, const std::string &data,
-			      const std::vector<std::string> &headers, long timeout_ms)
+HttpResponse HttpClient::post(const std::string &url, const std::string &data, const std::vector<std::string> &headers,
+			      long timeout_ms)
 {
 	HttpResponse response;
 	response.status = 0;
@@ -209,9 +209,8 @@ void HttpClient::getAsync(const std::string &url, const std::vector<std::string>
 	queue_cv.notify_one();
 }
 
-void HttpClient::postAsync(const std::string &url, const std::string &data,
-			   const std::vector<std::string> &headers, std::function<void(HttpResponse)> callback,
-			   long timeout_ms)
+void HttpClient::postAsync(const std::string &url, const std::string &data, const std::vector<std::string> &headers,
+			   std::function<void(HttpResponse)> callback, long timeout_ms)
 {
 	{
 		std::lock_guard<std::mutex> lock(queue_mutex);


### PR DESCRIPTION
Small defensive fix: make `HttpClient` teardown incapable of blocking OBS shutdown. Changes in `src/http_client.cpp` only (18 insertions, 3 deletions):

1. **Worker exits immediately on stop instead of draining the queue.** On `stop_worker` the worker discards pending requests and breaks. Previously it ran every queued request to completion — up to `timeout_ms` (10 s) each — during `obs_module_unload`.
2. **Skip callbacks once shutdown started.** A response completing during unload no longer invokes its callback, which could touch plugin state being destroyed.
3. **`cleanup()` detaches instead of joining.** Unload never waits for a request in flight. `curl_global_cleanup()` is skipped for the same reason (the worker may still be inside libcurl; it is optional at process exit).
4. **Guard `init()` against double init** (reload after a detached worker).

## Honest scope note

Today the async API has **zero callers** — all HTTP goes through the synchronous `HttpClient::get/post` (9 call sites in `bilibili_api.cpp`), so the worker queue is always empty and the old `join()` could not hang in practice. This PR is defensive hardening (an invariant: module unload must never block, and stale callbacks must never run), **not** a proven fix for the exit hang reported in issue 30. The most likely cause of that hang — OBS core's RTMP output send thread still alive and parked after "All scene data cleared" on a dead route to the RTMP server — is analyzed in the issue.

## Testing

- Built with CMake against OBS Studio 32.1.2 (NixOS) — clean compile.
- Lock discipline reviewed: the callback-skip check takes/releases `queue_mutex` without holding it across `req.callback`, so no deadlock with re-entrant `postAsync` from a callback.
