### PR TITLE
fix: hand release/ back to the runner user before archiving

### DIFF
--- a/.github/scripts/package-ubuntu
+++ b/.github/scripts/package-ubuntu
@@ -177,6 +177,11 @@ ${_usage_host:-}"
     local _tarflags='cJf'
     if (( _loglevel > 1 || ${+CI} )) _tarflags="v${_tarflags}"
 
+    # The package_source step above ran under sudo, so CPack created
+    # release/ as root; hand it back to the runner user, otherwise the
+    # archive below fails with "Cannot open: Permission denied".
+    sudo chown -R "$(id -u):$(id -g)" ${project_root}/release
+
     pushd ${project_root}/release/${config}
     XZ_OPT=-T0 tar "-${_tarflags}" ${project_root}/release/${output_name}.tar.xz (lib|share)
     popd


### PR DESCRIPTION
Fixes the Ubuntu CI failure that breaks every pull request (see the CI note on PR #31): the "Archiving" step fails with `tar: Cannot open: Permission denied` and exit code 2.

## Root cause

In `.github/scripts/package-ubuntu`, the Archiving branch (the `package:false` path, i.e. pull requests) runs after the source-tarball step, which is invoked under sudo:

```zsh
sudo cmake --build build_${target%%-*} --config ${config} -t package_source ...
```

CPack writes `release/bilibili-stream-for-obs-<ver>-source.tar.xz` as root, so it creates the `release/` directory owned by root. The subsequent Archiving step then runs as the unprivileged runner user:

```zsh
XZ_OPT=-T0 tar "-${_tarflags}" ${project_root}/release/${output_name}.tar.xz (lib|share)
```

and cannot create its output file inside root-owned `release/`. The failure from CI (job 95269468724):

```
tar (child): .../release/bilibili-stream-for-obs-2.1.3-x86_64-ubuntu-24.04-ubuntu-gnu.tar.xz: Cannot open: Permission denied
tar (child): Error is not recoverable: exiting now
tar: .../release/...tar.xz: Cannot write: Broken pipe
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

Why this only fails on pull requests: the `package:true` path (master pushes) never writes into `release/` as the runner user — it only lists it and renames with `sudo mv` — so the permission problem stays invisible there. This is pre-existing CI code (build-common template), unrelated to any plugin code change.

## Fix

Hand `release/` back to the runner user before archiving:

```zsh
sudo chown -R "$(id -u):$(id -g)" ${project_root}/release
```

## Verification

- Reproduced the exact failure locally by making `release/` non-writable (`chmod 0555`): tar dies with `Child returned status 2` / `Error is not recoverable`, same signature as CI.
- With `release/` writable again (the effect of the chown), the archive is created and lists the expected `lib/` content.
- The `package:true` branch is untouched.

## Note (out of scope, follow-up)

`package_source` runs under sudo because the plugin's own `install(TARGETS ...)` rule in `CMakeLists.txt` uses an absolute destination (`${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit`), which CPack source installs into the real system prefix (and adds `/` to `CPACK_SOURCE_INSTALLED_DIRECTORIES`). The build-common template already installs the plugin via `cmake/linux/helpers.cmake` (`${CMAKE_INSTALL_LIBDIR}/obs-plugins`), so the repo-level rule looks redundant; removing it would let package_source run without root and fix the whole class of problems. Happy to prepare that as a separate PR.
